### PR TITLE
adding user_undel and adding parameters to user_add

### DIFF
--- a/src/python_freeipa/client.py
+++ b/src/python_freeipa/client.py
@@ -116,7 +116,7 @@ class Client(object):
             return result['result']
 
     def user_add(self, username, first_name, last_name, full_name, display_name=None,
-                 noprivate=False, mail=None, ssh_key=None, job_title=None,
+                 noprivate=False, mail=None, ssh_key=None, job_title=None, gid_number=None, uid_number=None,
                  preferred_language=None, disabled=False, random_pass=False, initials=None, home_directory=None,
                  gecos=None, login_shell=None, user_password=None, street_address=None, city=None, state=None,
                  postal_code=None, telephone_number=None, mobile_number=None, pager_number=None, fax_number=None,
@@ -144,6 +144,10 @@ class Client(object):
         :type ssh_key: string or list
         :param job_title: Job title
         :type job_title: string
+        :param gid_number: gidNumber
+        :type gid_number: string
+        :param uid_number: uidNumber
+        :type uid_number: string
         :param preferred_language: Preferred language ISO code
         :type preferred_language: string
         :param disabled: Account disabled
@@ -203,6 +207,12 @@ class Client(object):
             'sn': last_name,
             'cn': full_name,
         }
+
+        if gid_number:
+            params['gidnumber'] = gid_number
+
+        if uid_number:
+            params['uidnumber'] = uid_number
 
         if display_name:
             params['displayname'] = display_name
@@ -565,6 +575,17 @@ class Client(object):
             'preserve': soft_delete,
         }
         return self._request('user_del', username, params)
+
+    def user_undel(self, username):
+        """
+        Undelete a user.
+
+        :param username: User login.
+        :type username: string
+        :param skip_errors: Continuous mode: Don't stop on errors.
+        :type skip_errors: bool
+        """
+        return self._request('user_undel', username)
 
     def passwd(self, login, password, current_password=None):
         """


### PR DESCRIPTION
In client.py I'm adding user_undel to allow restoring of preserved users.
I am also adding the gid_number and the uid_number parameters to user_add so that the uidNumber and gidNumber can be set upon user creation